### PR TITLE
[VideoStrip] Display video comment strip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,6 +1055,36 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-9.0.1.tgz",
       "integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA=="
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.19.tgz",
+      "integrity": "sha512-nd2Ul/CUs8U9sjofQYAALzOGpgkVJQgEhIJnOHaoyVR/LeC3x2mVg4eB910a4kS6WgLPebAY0M2fApEI497raQ=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.19.tgz",
+      "integrity": "sha512-D4ICXg9oU08eF9o7Or392gPpjmwwgJu8ecCFusthbID95CLVXOgIyd4mOKD9Nud5Ckz+Ty59pqkNtThDKR0erA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.19"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.9.0.tgz",
+      "integrity": "sha512-U8YXPfWcSozsCW0psCtlRGKjjRs5+Am5JJwLOUmVHFZbIEWzaz4YbP84EoPwUsVmSAKrisu3QeNcVOtmGml0Xw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.19"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz",
+      "integrity": "sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==",
+      "requires": {
+        "humps": "^2.0.1",
+        "prop-types": "^15.5.10"
+      }
+    },
     "@hapi/address": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
@@ -6172,6 +6202,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7553,9 +7588,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "dependencies": {
     "@blueprintjs/core": "^3.17.1",
     "@blueprintjs/icons": "^3.9.1",
+    "@fortawesome/fontawesome-svg-core": "^1.2.19",
+    "@fortawesome/free-solid-svg-icons": "^5.9.0",
+    "@fortawesome/react-fontawesome": "^0.1.4",
     "aws-amplify": "^1.1.29",
+    "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-bootstrap": "^1.0.0-beta.9",

--- a/src/components/CommentFeed.jsx
+++ b/src/components/CommentFeed.jsx
@@ -1,38 +1,25 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { API } from 'aws-amplify';
 import { Container, Spinner } from 'react-bootstrap';
 import CommentUpload from './CommentUpload';
 import CommentItem from './CommentItem';
 
 const propTypes = {
+  comments: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.number.isRequired })).isRequired,
+  handleSeek: PropTypes.func.isRequired,
+  videoProgress: PropTypes.number,
   videoId: PropTypes.number.isRequired,
-  userId: PropTypes.number.isRequired,
+  userId: PropTypes.number,
+};
+
+const defaultProps = {
+  userId: null,
+  videoProgress: 0,
 };
 
 class CommentFeed extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      comments: null,
-    };
-  }
-
-  async componentDidMount() {
-    const { videoId, userId } = this.props;
-
-    try {
-      const comments = await API.get('videocloud', `/comments/${videoId}/${userId}`);
-      this.setState({ comments });
-    } catch (error) {
-      console.error(error);
-    }
-  }
-
   renderAux() {
-    const { userId } = this.props;
-    const { comments } = this.state;
+    const { handleSeek, userId, comments } = this.props;
 
     if (comments === null) {
       return (
@@ -45,18 +32,22 @@ class CommentFeed extends Component {
     return (
       <div>
         {comments.map(comment => (
-          <CommentItem comment={comment} userId={userId} key={comment.id} />
+          <CommentItem handleSeek={handleSeek} comment={comment} userId={userId} key={comment.id} />
         ))}
       </div>
     );
   }
 
   render() {
-    const { videoId } = this.props;
+    const {
+      videoProgress,
+      videoId,
+      userId,
+    } = this.props;
 
     return (
       <Container className="CommentFeed">
-        <CommentUpload videoId={videoId} />
+        { userId ? <CommentUpload videoId={videoId} videoProgress={videoProgress} /> : null}
         { this.renderAux() }
       </Container>
     );
@@ -64,5 +55,6 @@ class CommentFeed extends Component {
 }
 
 CommentFeed.propTypes = propTypes;
+CommentFeed.defaultProps = defaultProps;
 
 export default CommentFeed;

--- a/src/components/CommentItem.jsx
+++ b/src/components/CommentItem.jsx
@@ -4,6 +4,7 @@ import { API } from 'aws-amplify';
 import { Link } from 'react-router-dom';
 import { Button, Container } from 'react-bootstrap';
 import './CommentItem.css';
+import { formatTimestamp } from '../utils';
 
 const propTypes = {
   comment: PropTypes.shape({
@@ -18,8 +19,13 @@ const propTypes = {
     createdAt: PropTypes.string,
     updatedAt: PropTypes.string,
   }).isRequired,
-  userId: PropTypes.number.isRequired,
+  handleSeek: PropTypes.func.isRequired,
+  userId: PropTypes.number,
 };
+
+const defaultProps = {
+  userId: null,
+}
 
 class CommentItem extends Component {
   constructor(props) {
@@ -38,7 +44,8 @@ class CommentItem extends Component {
   }
 
   handleClick() {
-    console.log("Todo: goto video frame at the specific timestamp");
+    const { handleSeek, comment: { timestamp } } = this.props;
+    handleSeek(timestamp);
   }
 
   async addLike() {
@@ -71,18 +78,20 @@ class CommentItem extends Component {
   }
 
   renderTimestamp(timestamp) {
-    if (timestamp >= 0) {
-      return (
-        <span className="grey">
-          {' - timestamp:'}
-          <Button variant="link" onClick={this.handleClick}>{timestamp}</Button>
-        </span>
-      );
-    }
-    return null;
+    return (
+      <span className="grey">
+        {' - timestamp:'}
+        <Button variant="link" onClick={this.handleClick}>{timestamp}</Button>
+      </span>
+    );
   }
 
   renderButton() {
+    const { userId } = this.props;
+    if (!userId) {
+      return;
+    }
+
     const { liked } = this.state;
 
     if (liked === 0) {
@@ -114,7 +123,7 @@ class CommentItem extends Component {
         </span>
         <p>
           {comment.content}
-          {this.renderTimestamp(comment.timestamp)}
+          {this.renderTimestamp(formatTimestamp(comment.timestamp))}
         </p>
         <span>
           {this.renderButton()}
@@ -126,5 +135,6 @@ class CommentItem extends Component {
 }
 
 CommentItem.propTypes = propTypes;
+CommentItem.defaultProps = defaultProps;
 
 export default CommentItem;

--- a/src/components/CommentUpload.jsx
+++ b/src/components/CommentUpload.jsx
@@ -4,9 +4,15 @@ import { API, Auth } from 'aws-amplify';
 import {
   Button, Col, Container, Form, Row,
 } from 'react-bootstrap';
+import { formatTimestamp } from '../utils';
 
 const propTypes = {
   videoId: PropTypes.number.isRequired,
+  videoProgress: PropTypes.number,
+};
+
+const defaultProps = {
+  videoProgress: 0,
 };
 
 class CommentUpload extends Component {
@@ -15,7 +21,6 @@ class CommentUpload extends Component {
 
     this.state = {
       content: '',
-      timestamp: '',
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -29,18 +34,9 @@ class CommentUpload extends Component {
     });
   }
 
-  defaultTimestamp() {
-    const { timestamp } = this.state;
-
-    if (timestamp === '') {
-      return -1;
-    }
-    return timestamp;
-  }
-
   async handleSubmit(event) {
     const { content } = this.state;
-    const { videoId } = this.props;
+    const { videoId, videoProgress } = this.props;
 
     event.preventDefault();
 
@@ -51,7 +47,7 @@ class CommentUpload extends Component {
         body: {
           content,
           video: videoId,
-          timestamp: this.defaultTimestamp(),
+          timestamp: videoProgress,
           created_by: user.attributes['custom:id'],
         },
       });
@@ -67,8 +63,8 @@ class CommentUpload extends Component {
   }
 
   render() {
-    const { content, timestamp } = this.state;
-    const videoDuration = 60; // TODO, fetch video length from S3 video url
+    const { content } = this.state;
+    const { videoProgress } = this.props;
 
     return (
       <Container className="CommentUpload">
@@ -84,16 +80,7 @@ class CommentUpload extends Component {
               </Form.Group>
             </Col>
             <Col md={3}>
-              <Form.Group controlId="timestamp">
-                <Form.Control
-                  type="number"
-                  min={0}
-                  max={videoDuration}
-                  onChange={this.handleChange}
-                  value={timestamp}
-                  placeholder="Select timestamp..."
-                />
-              </Form.Group>
+              <Form.Label>{`at ${formatTimestamp(videoProgress)}`}</Form.Label>
             </Col>
           </Row>
           <Button
@@ -110,5 +97,6 @@ class CommentUpload extends Component {
 }
 
 CommentUpload.propTypes = propTypes;
+CommentUpload.defaultProps = defaultProps;
 
 export default CommentUpload;

--- a/src/components/StripComment.jsx
+++ b/src/components/StripComment.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faComment } from '@fortawesome/free-solid-svg-icons';
+
+const stripCommentPropTypes = {
+  comment: PropTypes.shape({
+    content: PropTypes.string.isRequired,
+    timestamp: PropTypes.number.isRequired,
+    username: PropTypes.string.isRequired,
+  }).isRequired,
+  totalLength: PropTypes.number.isRequired,
+};
+
+const StripComment = (props) => {
+  const { comment, totalLength } = props;
+  const { timestamp } = comment;
+
+  return (
+    <OverlayTrigger
+      trigger="hover"
+      placement="bottom"
+      overlay={(
+        <Popover>
+          <strong>{`${comment.username}: `}</strong>
+          {comment.content}
+        </Popover>
+      )}
+    >
+      <FontAwesomeIcon
+        style={{ position: 'relative', left: timestamp * 1024 / totalLength }}
+        icon={faComment}
+        size="xs"
+        color="white"
+      />
+    </OverlayTrigger>
+  );
+};
+
+StripComment.propTypes = stripCommentPropTypes;
+
+export default StripComment;

--- a/src/components/VideoPlayer.jsx
+++ b/src/components/VideoPlayer.jsx
@@ -1,27 +1,87 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Container } from 'react-bootstrap';
 import ReactPlayer from 'react-player';
+import VideoStrip from './VideoStrip';
 import './VideoPlayer.css';
 
 const propTypes = {
+  comments: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   url: PropTypes.string.isRequired,
+  videoName: PropTypes.string.isRequired,
+  handleVideoProgressChange: PropTypes.func.isRequired,
 };
 
-export default function VideoPlayer(props) {
-  const { url } = props;
-  return (
-    <Container className="VideoPlayer" fluid>
-      <ReactPlayer
-        className="react-player mx-auto"
-        url={url}
-        loop
-        controls
-        width="100%"
-        height="100%"
-      />
-    </Container>
-  );
+class VideoPlayer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      progress: 0,
+      duration: 1,
+    };
+
+    this.player = null;
+
+    this.ref = (player) => {
+      this.player = player;
+    };
+
+    this.handleStripSeek = this.handleStripSeek.bind(this);
+    this.handleVideoDurationChange = this.handleVideoDurationChange.bind(this);
+    this.handleVideoProgressChange = this.handleVideoProgressChange.bind(this);
+  }
+
+  setProgress(seconds) {
+    this.handleStripSeek(seconds);
+  }
+
+  handleStripSeek(deltaSeconds) {
+    if (this.player) {
+      this.player.seekTo(deltaSeconds, 'seconds');
+    }
+  }
+
+  handleVideoProgressChange({ playedSeconds }) {
+    const { handleVideoProgressChange: parentProgressHandler } = this.props;
+    this.setState({ progress: playedSeconds });
+
+    parentProgressHandler(Math.floor(playedSeconds));
+  }
+
+  handleVideoDurationChange(duration) {
+    this.setState({ duration });
+  }
+
+  render() {
+    const { url, videoName, comments } = this.props;
+    const { duration, progress } = this.state;
+
+    return (
+      <Container className="VideoPlayer" fluid>
+        <ReactPlayer
+          ref={this.ref}
+          className="react-player mx-auto"
+          url={url}
+          controls
+          height="576px"
+          width="1024px"
+          progressInterval={10}
+          onDuration={this.handleVideoDurationChange}
+          onProgress={this.handleVideoProgressChange}
+        />
+        <VideoStrip
+          handleSeek={this.handleStripSeek}
+          videoName={videoName}
+          progress={progress}
+          totalLength={duration}
+          comments={comments}
+        />
+      </Container>
+    );
+  }
 }
 
 VideoPlayer.propTypes = propTypes;
+
+export default VideoPlayer;

--- a/src/components/VideoStrip.jsx
+++ b/src/components/VideoStrip.jsx
@@ -1,0 +1,220 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import { Card } from 'react-bootstrap';
+import { getFile } from '../lib/awsLib';
+import StripComment from './StripComment';
+
+const propTypes = {
+  handleSeek: PropTypes.func.isRequired,
+  progress: PropTypes.number.isRequired,
+  totalLength: PropTypes.number.isRequired,
+  videoName: PropTypes.string.isRequired,
+  comments: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    username: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
+  })).isRequired,
+};
+
+const imageNameFromVideoName = videoName => `strips/${videoName.split('/')[1].split('.')[0]}.png`;
+
+const overlapsActiveComment = (comment, activeCommentMap) => {
+  for (let i = -2; i < 5; i++) {
+    if (activeCommentMap[Math.round(comment.timestamp) + i]) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const overlapsPlacedIcon = (comment, totalLength, listedCommentMap) => {
+  const padding = 14 * totalLength / 1024; // 14 = width of the icon  + padding
+  for (let i = Math.round(comment.timestamp) - padding; i < Math.round(comment.timestamp) + padding; i++) {
+    if (listedCommentMap[i]) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+class VideoStrip extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activeComment: null,
+      activeComments: [],
+      listedComments: [],
+      moving: false,
+      showActiveComment: false,
+      stripImageLink: '',
+    };
+
+    this.handle = null;
+
+    this.handleHandleDrage = this.handleHandleDrag.bind(this);
+    this.ref = (handle) => { this.handle = handle; };
+  }
+
+  async componentDidMount() {
+    const { videoName } = this.props;
+
+    const imageName = imageNameFromVideoName(videoName);
+    const stripImageLink = await getFile(imageName);
+
+    this.setState({ stripImageLink });
+  }
+
+  componentDidUpdate(prevProps) {
+    const { progress, totalLength } = this.props;
+
+    if (prevProps.progress !== progress) {
+      this.updateActiveComments(progress);
+    }
+
+    if (prevProps.totalLength !== totalLength) {
+      this.updateCommentLists();
+    }
+  }
+
+  updateActiveComments() {
+    const { progress } = this.props;
+    const { activeComment, activeComments } = this.state;
+    let condition;
+
+    if (!activeComment) {
+      condition = true;
+    } else {
+      condition = Math.abs(progress - activeComment.timestamp) >= 2;
+    }
+
+    if (condition) {
+      for (let i = 0; i < activeComments.length; i++) {
+        const comment = activeComments[i];
+
+        if (Math.abs(comment.timestamp - progress) <= 0.1) {
+          this.setState({ activeComment: comment, showActiveComment: true });
+          break;
+        }
+
+        if (Math.abs(comment.timestamp - progress) <= 0.5) {
+          this.setState({ showActiveComment: false });
+          break;
+        }
+      }
+    }
+  }
+
+  updateCommentLists() {
+    const { comments, totalLength } = this.props;
+    const activeCommentMap = {};
+    const listedCommentMap = {};
+
+    comments.sort((c1, c2) => new Date(c1.createdAt) > new Date(c2.createdAt));
+
+    comments.forEach((comment) => {
+      if (!overlapsActiveComment(comment, activeCommentMap)) {
+        activeCommentMap[Math.round(comment.timestamp)] = comment;
+        listedCommentMap[Math.round(comment.timestamp)] = comment;
+      } else if (!overlapsPlacedIcon(comment, totalLength, listedCommentMap)) {
+        listedCommentMap[Math.round(comment.timestamp)] = comment;
+      }
+    });
+
+    const activeComments = [];
+    _.forEach(activeCommentMap, (comment) => {
+      activeComments.push(comment);
+    });
+
+    const listedComments = [];
+    _.forEach(listedCommentMap, (comment) => {
+      listedComments.push(comment);
+    });
+
+    this.setState({ activeComments, listedComments });
+  }
+
+  handleHandleDrag(event) {
+    event.preventDefault();
+
+    const { moving } = this.state;
+
+    if (!this.handle || !moving) {
+      return;
+    }
+
+    const { handleSeek, totalLength } = this.props;
+    const originalX = this.handle.getBoundingClientRect().left;
+    const drag = event.pageX - originalX;
+    const deltaSeconds = drag * totalLength / 1024;
+
+    handleSeek(deltaSeconds);
+  }
+
+  renderComment() {
+    const { activeComment, showActiveComment } = this.state;
+
+    if (!activeComment) {
+      return null;
+    }
+
+    const { username, content } = activeComment;
+
+    return (
+      <Card className={`activeComment ${showActiveComment ? 'show' : ''}`}>
+        <Card.Body>
+          <Card.Title>{`${username} said:`}</Card.Title>
+          <Card.Text>{content}</Card.Text>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  renderCommentIcons() {
+    const { totalLength } = this.props;
+    const { listedComments } = this.state;
+
+    return (
+      <div className="commentIcon">
+        {
+          listedComments.map(comment => (
+            <StripComment key={comment.id} comment={comment} totalLength={totalLength} />
+          ))
+        }
+      </div>
+    );
+  }
+
+  render() {
+    const { stripImageLink, moving } = this.state;
+    const { progress, totalLength } = this.props;
+    const playedWidth = 1024 * progress / totalLength;
+
+    return (
+      <div
+        className={`VideoStrip ${moving ? 'grabbing' : ''}`}
+        ref={this.ref}
+        onMouseDown={() => { this.setState({ moving: true }); }}
+        onMouseUp={(event) => {
+          this.setState({ moving: false });
+          this.handleHandleDrag(event);
+        }}
+        onMouseMove={(event) => { this.handleHandleDrag(event); }}
+      >
+        <img src={stripImageLink} alt="Video Strip" />
+        <div className="played" style={{ width: playedWidth }}>
+          <img src={stripImageLink} alt="Video Strip Dark" />
+        </div>
+        <div className="handle" style={{ left: playedWidth }} />
+        {this.renderCommentIcons()}
+        {this.renderComment()}
+      </div>
+    );
+  }
+}
+
+VideoStrip.propTypes = propTypes;
+
+export default VideoStrip;

--- a/src/containers/VideoItem.css
+++ b/src/containers/VideoItem.css
@@ -2,3 +2,75 @@
     margin-top: 75px;
     margin-bottom: 75px;
 }
+
+.VideoItem video {
+}
+
+.VideoStrip {
+  margin: 0 43px;
+  position: relative;
+  top: -35px;
+  max-height: 150px;
+}
+
+.VideoStrip img {
+  border-top: 3px solid black;
+  border-bottom: 1px solid grey;
+  width: 1024px;
+  border-radius: 0 0 5px 5px;
+  filter: brightness(50%);
+}
+
+.VideoStrip .played {
+  overflow-x: hidden;
+  z-index: 1;
+  position: relative;
+  top: -32px;
+}
+
+.VideoStrip .played img {
+  filter: brightness(100%);
+}
+
+.VideoStrip .handle {
+  max-width: 5px;
+  min-height: 33px;
+  background-color: #ffffff;
+  z-index: 100;
+  position: relative;
+  top: -64px;
+  border-radius: 5px;
+}
+
+.VideoStrip.grabbing {
+  cursor: grab;
+}
+
+.VideoStrip .handle:hover {
+  cursor: grab;
+}
+
+.VideoStrip .activeComment {
+  min-height: 100px;
+  position: relative;
+  top: -60px;
+  border-radius: 0 15px 15px 15px;
+  transition: 0.3s;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.VideoStrip .activeComment.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+.VideoStrip .commentIcon {
+  top: -84px;
+  position: relative;
+  z-index: 4;
+}
+
+.active {
+  color: black;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,5 @@
+export const formatTimestamp = seconds => (
+  new Date(seconds * 1000)
+    .toISOString()
+    .substr(seconds > 3600 ? 11 : 14, seconds > 3600 ? 8 : 5)
+);


### PR DESCRIPTION
## Description

Displays a strip containing 20 equally spaced screenshots of the video,
with markers displaying where users commented. Users can see the
comments by hovering over the marking icon.

Highlighted comments show up under the video at the same timestamp where
the comment was made.

Other changes:
- Non logged in users are allowed to watch the video, but not comment
- The timestamp of the comment is not set by the user, but automatically
  set at the timestamp of the video, when the user comments.

## Testing

Manually tested by verifying that comments show up on the video strip, hovering over the markers displays comments, and clicking on the comment timestamp causes the video to go to the timestamp of the comment.

Also verified that as a logged out user, I could do the same things, but not comment.