### PR TITLE
[Export] Add a button to export a video

### DIFF
--- a/src/components/VideoPlayer.jsx
+++ b/src/components/VideoPlayer.jsx
@@ -20,6 +20,7 @@ class VideoPlayer extends Component {
     const { startResolution } = this.props;
 
     this.state = {
+      activeComments: [],
       progress: 0,
       duration: 1,
       playing: false,
@@ -32,6 +33,7 @@ class VideoPlayer extends Component {
       this.player = player;
     };
 
+    this.handleActiveComments = this.handleActiveComments.bind(this);
     this.handleStripSeek = this.handleStripSeek.bind(this);
     this.handleResolutionChange = this.handleResolutionChange.bind(this);
     this.handleVideoDurationChange = this.handleVideoDurationChange.bind(this);
@@ -40,6 +42,10 @@ class VideoPlayer extends Component {
 
   setProgress(seconds) {
     this.handleStripSeek(seconds);
+  }
+
+  handleActiveComments(activeComments) {
+    this.setState({ activeComments });
   }
 
   handleStripSeek(deltaSeconds) {
@@ -72,6 +78,7 @@ class VideoPlayer extends Component {
       startResolution,
     } = this.props;
     const {
+      activeComments,
       duration,
       playing,
       progress,
@@ -81,9 +88,11 @@ class VideoPlayer extends Component {
     return (
       <Container className="VideoPlayer" fluid>
         <VideoControls
+          activeComments={activeComments}
           defaultResolution={startResolution}
           handleResolutionChange={this.handleResolutionChange}
           resolutions={Object.keys(urls)}
+          videoName={videoName}
         />
         <ReactPlayer
           ref={this.ref}
@@ -98,6 +107,7 @@ class VideoPlayer extends Component {
           onProgress={this.handleVideoProgressChange}
         />
         <VideoStrip
+          handleActiveComments={this.handleActiveComments}
           handleSeek={this.handleStripSeek}
           videoName={videoName}
           progress={progress}

--- a/src/components/VideoStrip.jsx
+++ b/src/components/VideoStrip.jsx
@@ -6,6 +6,7 @@ import { getFile } from '../lib/awsLib';
 import StripComment from './StripComment';
 
 const propTypes = {
+  handleActiveComments: PropTypes.func.isRequired,
   handleSeek: PropTypes.func.isRequired,
   progress: PropTypes.number.isRequired,
   totalLength: PropTypes.number.isRequired,
@@ -54,7 +55,7 @@ class VideoStrip extends Component {
 
     this.handle = null;
 
-    this.handleHandleDrage = this.handleHandleDrag.bind(this);
+    this.handleHandleDrag = this.handleHandleDrag.bind(this);
     this.ref = (handle) => { this.handle = handle; };
   }
 
@@ -108,7 +109,7 @@ class VideoStrip extends Component {
   }
 
   updateCommentLists() {
-    const { comments, totalLength } = this.props;
+    const { comments, handleActiveComments, totalLength } = this.props;
     const activeCommentMap = {};
     const listedCommentMap = {};
 
@@ -134,6 +135,7 @@ class VideoStrip extends Component {
     });
 
     this.setState({ activeComments, listedComments });
+    handleActiveComments(activeComments);
   }
 
   handleHandleDrag(event) {

--- a/src/containers/VideoItem.css
+++ b/src/containers/VideoItem.css
@@ -50,10 +50,15 @@
   cursor: grab;
 }
 
-.QualityControl {
+.Controls {
   position: relative;
   left: 45px;
   bottom: 5px;
+}
+
+.Controls .dropdown {
+  display: inline;
+  margin-right: 5px;
 }
 
 .VideoStrip .activeComment {


### PR DESCRIPTION
## Description

Adds an `Export Video` button on the video page, which triggers an API
call and displays the link to the ZIP file containing the video and the
comments as a subtitle that the user can download.

## Testing

Manually tested